### PR TITLE
Add tdbcli compilation to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,11 @@ include_HEADERS = \
   src/tdb_types.h \
   src/tdb_limits.h
 
-bin_PROGRAMS = util/traildb_bench
+bin_PROGRAMS = util/traildb_bench tdb/tdbcli
 util_traildb_bench_SOURCES = util/traildb_bench.c
 util_traildb_bench_CFLAGS  = ${libtraildb_la_CFLAGS} -Isrc/
 util_traildb_bench_LDADD   = libtraildb.la
+
+tdb_tdbcli_SOURCES = tdb/main.c tdb/op_dump.c tdb/op_make.c tdb/jsmn/jsmn.c
+tdb_tdbcli_CFLAGS = ${libtraildb_la_CFLAGS} -Isrc/
+tdb_tdbcli_LDADD = libtraildb.la


### PR DESCRIPTION
This patch is correct, but it makes the whole build fails with
this error:

```
Undefined symbols for architecture x86_64:
  "_judyerror_macro_missing_fix_this", referenced from:
      _op_make in tdb_tdbcli-op_make.o
      _populate_fields in tdb_tdbcli-op_make.o
```

The problem comes from line 4 of Makefile.am:

```
                       -DJUDYERROR=judyerror_macro_missing_fix_this \
```

Once this line is either removed or modified with a working
function, this patch will work correctly.
