### PR TITLE
tdbcli: add --skip-bad-input to be lenient on input errors.

### DIFF
--- a/tdb/main.c
+++ b/tdb/main.c
@@ -74,6 +74,7 @@ static void initialize(int argc, char **argv, int op)
         {"tdb-format", required_argument, 0, 't'},
         {"csv-header", no_argument, 0, -2},
         {"json-no-empty", no_argument, 0, -3},
+        {"skip-bad-input", no_argument, 0, -4},
         {0, 0, 0, 0}
     };
 
@@ -138,6 +139,9 @@ static void initialize(int argc, char **argv, int op)
                 break;
             case -3:
                 options.json_no_empty = 1;
+                break;
+            case -4:
+                options.skip_bad_input = 1;
                 break;
             default:
                 print_usage_and_exit();

--- a/tdb/tdbcli.h
+++ b/tdb/tdbcli.h
@@ -6,6 +6,11 @@
 
 #include <Judy.h>
 
+#define ERR_OR_DIE(die, msg, ...)\
+    do { fprintf(stderr, msg"\n", ##__VA_ARGS__); \
+         if (die) { exit(EXIT_FAILURE); } \
+       } while (0)
+
 #define DIE(msg, ...)\
     do { fprintf(stderr, msg"\n", ##__VA_ARGS__);   \
          exit(EXIT_FAILURE); } while (0)
@@ -32,6 +37,7 @@ struct tdbcli_options{
     const char *delimiter;
     uint64_t output_format;
     int output_format_is_set;
+    int skip_bad_input;
 };
 
 #define FORMAT_CSV 0


### PR DESCRIPTION
This new command line option converts the current die errors
triggered in case of malformed input (eg: invalid uuid format)
into "simple" errors, skipping the malformed lines.
