### PR TITLE
show exit status on failing test

### DIFF
--- a/tests/support/test.py
+++ b/tests/support/test.py
@@ -24,7 +24,7 @@ class Testing:
             os.system("chmod +x %s" % path)
             result = os.system("%s \"%s\"" % (path, temp_dir_path))
             if result != 0:
-                print("FAILED: %s %s" % (cfile, msg))
+                print("FAILED: %s %s with status %s" % (cfile, msg, result))
                 self.failed_tests.add(cfile)
             else:
                 print("SUCCEEDED: %s %s" % (cfile, msg))


### PR DESCRIPTION
There are currently some tests that are failing that are failing on OS X. I think it would make sense to show an exit status for failing tests to make it easier to track them down.

Related to https://github.com/SemanticSugar/traildb/issues/49
