### PR TITLE
ignore certain tests on OS X

### DIFF
--- a/test-driver.py
+++ b/test-driver.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import signal
+import time
+import sys
+
+oldcwd = os.getcwd()
+
+tester = None
+
+def main():
+    # add source directory
+    global tester
+    old_cflags = os.getenv("CFLAGS", "")
+    build_dir = oldcwd + "/build"
+    include = oldcwd + "/src"
+
+    cflags = "%s -L %s -I%s" % (old_cflags, build_dir, include)
+
+    os.putenv("CFLAGS", cflags)
+    os.putenv("LD_LIBRARY_PATH", build_dir)
+
+    os.chdir("./tests")
+    
+    tester = subprocess.Popen(["./support/test.py"])
+    tester.wait()
+
+def stop_tester(signal, frame):
+    if tester is not None:
+        for x in range(4):
+            if tester.returncode is None:
+                tester.terminate()
+                time.sleep(1)
+
+    if tester.returncode is None:
+        tester.kill()
+
+    sys.exit(2)
+
+if __name__ == "__main__":
+    print "Run ./waf install --test_build before running this!"
+    signal.signal(signal.SIGINT, stop_tester)
+    main()

--- a/tests/support/OSX_IGNORE.txt
+++ b/tests/support/OSX_IGNORE.txt
@@ -1,0 +1,2 @@
+c-tests/judy_128_map_test.c
+c-tests/out_of_memory.c

--- a/tests/support/test.py
+++ b/tests/support/test.py
@@ -3,13 +3,21 @@ import tempfile
 import shutil
 import sys
 import os
+import platform
+from os.path import dirname
 
 class Testing:
     def __init__(self):
         self.failed_tests = set()
         self.succeeded_tests = set()
+        self.ignore_tests = set()
 
     def runCTest(self, cfile, msg=''):
+        if osname == "Darwin":
+            if cfile in osx_ignore:
+                print "SKIPPED: %s" % cfile
+                return
+
         (handle, path) = tempfile.mkstemp()
         temp_dir_path = tempfile.mkdtemp()
         try:
@@ -75,6 +83,12 @@ class Testing:
         return 0
 
 if __name__ == '__main__':
+    osx_ignore_file = dirname(__file__) + '/OSX_IGNORE.txt'
+    osx_ignore = set(line.rstrip("\n") for line in open(osx_ignore_file))
+    osname = platform.system()
+
+    print osx_ignore
+
     t = Testing()
     sys.exit(t.runTests(**{k: True for k in sys.argv[1:]}))
 


### PR DESCRIPTION
there's a python launcher (that handles Ctrl-C properly), the bash script doesn't. also some tests that don't work right on OS X are ignored on OS X.
