### PR TITLE
Fix judy installation instruction after recent move to homebrew/boneyard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python judy libarchive; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python libarchive homebrew/boneyard/judy; fi
   - pip install --user cpp-coveralls
 
 addons:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For RPM-based distros:
 
 For OSX:
 
-	$ brew install judy libarchive pkg-config
+	$ brew install homebrew/boneyard/judy libarchive pkg-config
 
 For FreeBSD:
 

--- a/wscript
+++ b/wscript
@@ -21,7 +21,7 @@ errmsg_judy = "not found"
 
 if sys.platform == "darwin":
     errmsg_libarchive = "not found; install with 'brew install libarchive'"
-    errmsg_judy = "not found; install with 'brew install judy && brew link judy'"
+    errmsg_judy = "not found; install with 'brew install homebrew/boneyard/judy && brew link judy'"
 
 def configure(cnf):
     cnf.load("compiler_c")


### PR DESCRIPTION
Judy is not part of the main homebrew repository anymore, so we need to update installation instructions.