### PR TITLE
Escape characters in JSON dump in tdb dump

### DIFF
--- a/tdbcli/op_dump.c
+++ b/tdbcli/op_dump.c
@@ -64,6 +64,39 @@ static void dump_csv_event(FILE *output,
     SAFE_FPRINTF("\n");
 }
 
+/* Add a backslash before the given character. If no occurences of the
+   character was found, returns the original string. If escaping is
+   necessary, a new string is allocated which must later be freed. The
+   length of the new string is set in the 'outlen' argument. */
+
+uint8_t * escape(const uint8_t *s, uint64_t len, uint64_t *outlen, uint8_t c) {
+    /* How many chars do we need to escape? */
+    int num = 0;
+    for (int i = 0; i < len; i++)
+        if (s[i] == c)
+            num++;
+
+    if (!num)
+        return (uint8_t *) s;
+
+    /* Allocate a buffer with enough space */
+    uint8_t *buf = malloc(len+num);
+    if(!buf)
+        DIE("Out of memory.");
+
+    /* Iterate through the source string, copying characters and
+       adding escape characters as necessary. */
+    int j = 0;
+    for (int i = 0; i < len; i++) {
+        if (s[i] == c)
+            buf[j++] = '\\';
+
+        buf[j++] = s[i];
+    }
+    *outlen = j;
+    return buf;
+}
+
 static void dump_json_event(FILE *output,
                             const struct tdbcli_options *opt,
                             const char **out_values,
@@ -77,11 +110,20 @@ static void dump_json_event(FILE *output,
     SAFE_FPRINTF("{");
     for (i = 0; i < opt->num_fields; i++)
         if (out_lengths[i] || !opt->json_no_empty){
+
+            uint64_t len = out_lengths[i];
+            const uint8_t *str = out_values[i];
+            uint8_t *maybe_escaped = escape(str, len, &len, '"');
+
             SAFE_FPRINTF("%s\"%s\": \"%.*s\"",
                          prefix,
                          opt->field_names[i],
-                         (int)out_lengths[i],
-                         out_values[i]);
+                         (int)len,
+                         maybe_escaped);
+
+            if (str != maybe_escaped)
+                free(maybe_escaped);
+
             prefix = PREFIX2;
         }
     SAFE_FPRINTF("}\n");


### PR DESCRIPTION
If a field in a TrailDB contains double quotes (`"`), `tdb dump --json` does not add the escape parenthesis. This patch handles this particular case, but not other escape characters (like newline).

I tried to keep the change simple and performant. It will only allocate and copy the string if replacement is needed, which most likely will happen very rarely. If no modification is needed, no allocation or copy is done.

I'm a bit unsure about the convention around freeing memory so I'm happy to take another pass if there's a better way.

As a side note, there's quite a few different ways we could speed up the replacement and I'd be happy to do another pass to improve performance.