### PR TITLE
create a Dockerfile for building tdb base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+  
+FROM ubuntu:16.04
+
+MAINTAINER Chia-Chi Chang <c3h3.tw@gmail.com>
+
+
+ENV DEBIAN_FRONTEND noninteractive
+
+
+RUN apt-get update && apt-get install -y libarchive-dev libjudy-dev pkg-config git-core build-essential gfortran sudo make cmake libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm vim python
+
+RUN cd /tmp && git clone https://github.com/traildb/traildb.git && cd traildb && ./waf configure && ./waf install && cd /tmp && rm -rf traildb/
+
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+
+


### PR DESCRIPTION
Dear @tuulos :

I just separated the original Dockerfile into two Dockerfiles.

Here is the base image.
I tried to pull it and run it up ... it works. 
Here is the snapshots:

![image](https://cloud.githubusercontent.com/assets/748256/17650963/81a3436a-6210-11e6-90af-ad6fca645090.png)


![image](https://cloud.githubusercontent.com/assets/748256/17650969/a2d7a864-6210-11e6-94ce-2c797e42efd7.png)

Another Dockerfile with python-client and ipython notebook binding is here:
https://github.com/traildb/traildb-python/pull/9
