### PR TITLE
tdb_iter interface

### DIFF
--- a/src/tdb_iter.c
+++ b/src/tdb_iter.c
@@ -1,0 +1,31 @@
+#include "tdb_internal.h"
+
+TDB_EXPORT tdb_iter *tdb_iter_new(const tdb *db, const struct tdb_event_filter *filter) {
+  tdb_iter *iter = calloc(1, sizeof(tdb_iter));
+  if (iter == NULL)
+    return NULL;
+  if ((iter->cursor = tdb_cursor_new(db)) == NULL) {
+    free(iter);
+    return NULL;
+  }
+  if (filter)
+    if (tdb_cursor_set_event_filter(iter->cursor, filter) != TDB_ERR_OK) {
+      tdb_iter_free(iter);
+      return NULL;
+    }
+  return iter;
+}
+
+TDB_EXPORT tdb_iter *tdb_iter_next(tdb_iter *restrict iter) {
+  while (iter->marker++ < iter->cursor->state->db->num_trails) {
+    if (tdb_get_trail(iter->cursor, iter->marker - 1) == TDB_ERR_OK)
+      if (tdb_cursor_peek(iter->cursor))
+        return iter;
+  }
+  return NULL;
+}
+
+TDB_EXPORT void tdb_iter_free(tdb_iter *iter) {
+  free(iter->cursor);
+  free(iter);
+}

--- a/src/tdb_types.h
+++ b/src/tdb_types.h
@@ -63,6 +63,11 @@ typedef struct{
     uint64_t num_events_left;
 } tdb_cursor;
 
+typedef struct{
+    uint64_t marker;
+    tdb_cursor *cursor;
+} tdb_iter;
+
 typedef struct tdb_multi_cursor tdb_multi_cursor;
 
 #define tdb_item_field32(item) (item & 127)

--- a/src/traildb.h
+++ b/src/traildb.h
@@ -217,6 +217,21 @@ int _tdb_cursor_next_batch(tdb_cursor *cursor);
 
 /*
 ------------
+Trails Iter
+------------
+*/
+
+/* Create a new iter */
+tdb_iter *tdb_iter_new(const tdb *db, const struct tdb_event_filter *filter);
+
+/* Load the next cursor / id into the iter */
+tdb_iter *tdb_iter_next(tdb_iter *iter);
+
+/* Free the iter */
+void tdb_iter_free(tdb_iter *iter);
+
+/*
+------------
 Multi cursor
 ------------
 */


### PR DESCRIPTION
The iter interface enables significant performance gain in languages where looping through the entire TrailDB is slow (e.g. 100-1000x in Python), and at least some small gain in pretty much all languages. 