### PR TITLE
Add TDB_OPT_CONS_NO_BIGRAMS to disable bigram optimization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### New features
 
+  - `TDB_OPT_CONS_NO_BIGRAMS` option for [tdb_cons_set_opt](http://traildb.io/docs/api/#tdb_cons_set_opt) to disable bigram-based size optimization. This option can sometimes greatly speed up TrailDB creation at the cost of increased filesize. The flag can also be passed to `tdb` CLI as `--no-bigrams`.
+
   - Trail-level options: [tdb_set_trail_opt](http://traildb.io/docs/api/#tdb_set_trail_opt). This is especially useful for creating granular views using `TDB_OPT_EVENT_FILTER`. See [Setting Options](http://traildb.io/docs/api/#setting-options).
 
   - Time-range term: [query events within a given time-range](http://traildb.io/docs/api/#tdb_event_filter_add_time_range). This simplifies time-series type analyses of trails. Also expanded the filter inspection API to add functions for [counting the number of terms in a clause](http://traildb.io/docs/api/#tdb_event_filter_num_terms), [inspecting the type of a term](http://traildb.io/docs/api/#tdb_event_filter_get_term_type), and [returning the start and end times of a time-range term](http://traildb.io/docs/api/#tdb_event_filter_get_time_range).

--- a/doc/docs/api.md
+++ b/doc/docs/api.md
@@ -82,6 +82,10 @@ Currently the supported options are:
     - value `TDB_OPT_CONS_OUTPUT_PACKAGE` create a one-file TrailDB (default).
     - value `TDB_OPT_CONS_OUTPUT_DIR` do not package TrailDB, keep a directory.
 
+* key `TDB_OPT_CONS_NO_BIGRAMS`
+    - value `0` to enable bigram-based size optimization at TrailDB finalization (default). This decreases the size of resulting TrailDB at the cost of increased compression time.
+    - value `1` to disable bigram-based size optimization at TrailDB finalization.
+
 Return 0 on success, an error code otherwise.
 
 ### tdb_cons_get_opt

--- a/src/tdb_cons.c
+++ b/src/tdb_cons.c
@@ -728,6 +728,9 @@ TDB_EXPORT tdb_error tdb_cons_set_opt(tdb_cons *cons,
                 default:
                     return TDB_ERR_INVALID_OPTION_VALUE;
             }
+        case TDB_OPT_CONS_NO_BIGRAMS:
+            cons->no_bigrams = !(!(value.value));
+            return 0;
         default:
             return TDB_ERR_UNKNOWN_OPTION;
     }
@@ -740,6 +743,9 @@ TDB_EXPORT tdb_error tdb_cons_get_opt(tdb_cons *cons,
     switch (key){
         case TDB_OPT_CONS_OUTPUT_FORMAT:
             value->value = cons->output_format;
+            return 0;
+        case TDB_OPT_CONS_NO_BIGRAMS:
+            value->value = cons->no_bigrams;
             return 0;
         default:
             return TDB_ERR_UNKNOWN_OPTION;

--- a/src/tdb_encode.c
+++ b/src/tdb_encode.c
@@ -487,13 +487,17 @@ tdb_error tdb_encode(tdb_cons *cons, const tdb_item *items)
     TDB_TIMER_END("trail/collect_unigrams");
 
     /* 4. construct uni/bi-grams */
+    tdb_opt_value dont_build_bigrams;
+    tdb_cons_get_opt(cons, TDB_OPT_CONS_NO_BIGRAMS, &dont_build_bigrams);
+
     TDB_TIMER_START
     if ((ret = make_grams(grouped_r,
                           num_events,
                           items,
                           num_fields,
                           unigram_freqs,
-                          &gram_freqs)))
+                          &gram_freqs,
+                          dont_build_bigrams.value)))
         goto done;
     TDB_TIMER_END("trail/gram_freqs");
 

--- a/src/tdb_encode_model.c
+++ b/src/tdb_encode_model.c
@@ -420,6 +420,8 @@ tdb_error make_grams(FILE *grouped,
         TDB_TIMER_END("encode_model/all_bigrams")
     }
 
+    /* TODO: choose_grams below could also be optimized when !no_bigrams is true. */
+
     /* collect frequencies of non-overlapping bigrams and unigrams
        (exact covering set for each event), store in final_freqs */
     TDB_TIMER_START

--- a/src/tdb_encode_model.c
+++ b/src/tdb_encode_model.c
@@ -385,7 +385,8 @@ tdb_error make_grams(FILE *grouped,
                      const tdb_item *items,
                      uint64_t num_fields,
                      const Pvoid_t unigram_freqs,
-                     struct judy_128_map *final_freqs)
+                     struct judy_128_map *final_freqs,
+                     uint64_t no_bigrams)
 {
     struct ngram_state g = {.final_freqs = final_freqs};
     Word_t tmp;
@@ -411,11 +412,13 @@ tdb_error make_grams(FILE *grouped,
     TDB_TIMER_END("encode_model/find_candidates")
 
     /* collect frequencies of *all* occurring bigrams of candidate unigrams */
-    TDB_TIMER_START
-    ret = event_fold(all_bigrams, grouped, num_events, items, num_fields, &g);
-    if (ret)
-        goto done;
-    TDB_TIMER_END("encode_model/all_bigrams")
+    if (!no_bigrams) {
+        TDB_TIMER_START
+        ret = event_fold(all_bigrams, grouped, num_events, items, num_fields, &g);
+        if (ret)
+            goto done;
+        TDB_TIMER_END("encode_model/all_bigrams")
+    }
 
     /* collect frequencies of non-overlapping bigrams and unigrams
        (exact covering set for each event), store in final_freqs */

--- a/src/tdb_encode_model.h
+++ b/src/tdb_encode_model.h
@@ -36,7 +36,8 @@ int make_grams(FILE *grouped,
                const tdb_item *items,
                uint64_t num_fields,
                const Pvoid_t unigram_freqs,
-               struct judy_128_map *final_freqs);
+               struct judy_128_map *final_freqs,
+               uint64_t no_bigrams);
 
 Pvoid_t collect_unigrams(FILE *grouped,
                          uint64_t num_events,

--- a/src/tdb_internal.h
+++ b/src/tdb_internal.h
@@ -109,6 +109,7 @@ struct _tdb_cons {
     /* options */
 
     uint64_t output_format;
+    uint64_t no_bigrams;
 };
 
 struct tdb_file {

--- a/src/tdb_types.h
+++ b/src/tdb_types.h
@@ -106,7 +106,8 @@ typedef enum{
     TDB_OPT_CURSOR_EVENT_BUFFER_SIZE = 102,
 
     /* writing */
-    TDB_OPT_CONS_OUTPUT_FORMAT = 1001
+    TDB_OPT_CONS_OUTPUT_FORMAT = 1001,
+    TDB_OPT_CONS_NO_BIGRAMS = 1002,
 
 } tdb_opt_key;
 

--- a/tdbcli/main.c
+++ b/tdbcli/main.c
@@ -76,6 +76,7 @@ static void print_usage_and_exit()
 "--tdb-format      TrailDB output format:\n"
 "                   'pkg' for the default one-file format,\n"
 "                   'dir' for a directory\n"
+"--no-bigrams      when building TrailDBS, do not build and compress with bigrams\n"
 "-v --verbose      print diagnostic output to stderr\n"
 "\n"
 "FIELD SPECIFICATION:\n"
@@ -153,6 +154,7 @@ static int initialize(int argc, char **argv, int op)
         {"skip-bad-input", no_argument, 0, -5},
         {"index-path", required_argument, 0, -6},
         {"no-index", no_argument, 0, -7},
+        {"no-bigrams", no_argument, 0, -8},
         {0, 0, 0, 0}
     };
 
@@ -241,6 +243,9 @@ static int initialize(int argc, char **argv, int op)
                 break;
             case -7:
                 options.no_index = 1;
+                break;
+            case -8:
+                options.no_bigrams = 1;
                 break;
             default:
                 print_usage_and_exit();

--- a/tdbcli/op_make.c
+++ b/tdbcli/op_make.c
@@ -388,6 +388,14 @@ int op_make(struct tdbcli_options *opt)
             DIE("Invalid --tdb-format. "
                 "Maybe TrailDB was compiled without libarchive");
 
+    if (opt->no_bigrams)
+        if (tdb_cons_set_opt(cons,
+                             TDB_OPT_CONS_NO_BIGRAMS,
+                             opt_val(1)))
+            DIE("Invalid --no-bigrams. "
+                "TrailDB library doesn't understand TDB_OPT_CONS_NO_BIGRAMS; "
+                "library not up-to-date?");
+
     if (strcmp(opt->input, "-")){
         if (!(input = fopen(opt->input, "r")))
             DIE("Could not open input file %s", opt->input);

--- a/tdbcli/op_merge.c
+++ b/tdbcli/op_merge.c
@@ -98,6 +98,14 @@ int op_merge(struct tdbcli_options *opt,
             DIE("Invalid --tdb-format. "
                 "Maybe TrailDB was compiled without libarchive");
 
+    if (opt->no_bigrams)
+        if (tdb_cons_set_opt(cons,
+                             TDB_OPT_CONS_NO_BIGRAMS,
+                             opt_val(1)))
+            DIE("Invalid --no-bigrams. "
+                "TrailDB library doesn't understand TDB_OPT_CONS_NO_BIGRAMS; "
+                "library not up-to-date?");
+
     /* set the filter if set */
     if (opt->filter_arg){
         for (i = 0; i < num_inputs; i++){

--- a/tdbcli/tdbcli.h
+++ b/tdbcli/tdbcli.h
@@ -25,6 +25,9 @@ struct tdbcli_options{
 
     char *fields_arg;
 
+    /* compression */
+    int no_bigrams;
+
     /* fields */
     Pvoid_t csv_input_fields;
     uint64_t output_fields[TDB_MAX_NUM_FIELDS + 2];

--- a/tests/c-tests/tdb_test.h
+++ b/tests/c-tests/tdb_test.h
@@ -8,6 +8,15 @@
 
 static inline void test_cons_settings(tdb_cons *cons)
 {
+    if (getenv("TDB_CONS_NO_BIGRAMS")) {
+        assert(tdb_cons_set_opt(cons,
+                                TDB_OPT_CONS_NO_BIGRAMS,
+                                opt_val(1)) == 0);
+    } else {
+        assert(tdb_cons_set_opt(cons,
+                                TDB_OPT_CONS_NO_BIGRAMS,
+                                opt_val(0)) == 0);
+    }
 #ifdef __HAVE_ARCHIVE_H__
     if (getenv("TDB_CONS_OUTPUT_FORMAT")){
         assert(tdb_cons_set_opt(cons,


### PR DESCRIPTION
@tuulos 

This can significantly decrease the time it takes to finalize a TrailDB at tdb_cons_finalize() at the cost of increase in TrailDB filesize, with no change in the actual contents of the TrailDB.
