### PR TITLE
Update getting_started.md

### DIFF
--- a/doc/docs/getting_started.md
+++ b/doc/docs/getting_started.md
@@ -33,6 +33,12 @@ library and the `tdb` command line tool to a system-wide directory with
 ./waf install
 ```
 
+Rebuild the shared library cache:
+
+```sh
+ldconfig
+```
+
 That's all. See below for instructions for testing the installation.
 
 Alternatively, TrailDB provides an autotools-based build system which


### PR DESCRIPTION
> tdb dump -i test
tdb: error while loading shared libraries: libtraildb.so.0: cannot open shared object file: No such file or directory

Then I realized that "ldconfig" should be run after the installation.