### PR TITLE
Fix several issues with merge in tdbcli

### DIFF
--- a/tdbcli/op_merge.c
+++ b/tdbcli/op_merge.c
@@ -123,10 +123,7 @@ static tdb **open_tdbs(const char **inputs,
         // compare number of fields -- skip over timestamp
         n = tdb_num_fields(dbs[i]) - 1;
         if (n != *num_user_fields) {
-            printf("Unequal number of fields: %lu and %lu\n",
-                   *num_user_fields,
-                   n);
-            equal_fields = 0;
+            *equal_fields = 0;
             break;
         }
 

--- a/tdbcli/op_merge.c
+++ b/tdbcli/op_merge.c
@@ -110,51 +110,80 @@ static tdb **open_tdbs(const char **inputs,
     if (!(dbs = malloc(num_inputs * sizeof(tdb*))))
         DIE("Out of memory");
 
-    // count only user-defined fields, not including timestamp
-    *num_user_fields = 0;
-    *equal_fields = 1;
-    for (i = 0; i < num_inputs; i++){
-        dbs[i] = open_tdb(inputs[i]);
-        // ignore timestamp
-        n = tdb_num_fields(dbs[i]) - 1;
+     for(i = 0; i < num_inputs; i++) {
+         dbs[i] = open_tdb(inputs[i]);
+     }
 
-        for (j = 0; j < n; j++){
-            // skip over timestamp
-            const char *key = tdb_get_field_name(dbs[i], j + 1);
-            JSLI(ptr, dedup_fields, key);
-            if (!*ptr){
-                if (i > 0)
-                    *equal_fields = 0;
-                *ptr = (Word_t)key;
-                ++*num_user_fields;
+    // count only user-defined fields, not including timestamp
+    *num_user_fields = tdb_num_fields(dbs[0]) - 1;
+    *equal_fields = 1;
+
+    // check for special case of all equal fields
+    for(i = 1; i < num_inputs; i++) {
+        // compare number of fields -- skip over timestamp
+        n = tdb_num_fields(dbs[i]) - 1;
+        if (n != *num_user_fields) {
+            printf("Unequal number of fields: %lu and %lu\n",
+                   *num_user_fields,
+                   n);
+            equal_fields = 0;
+            break;
+        }
+
+        // compare field names and ordering -- skip over timestamp
+        for (j = 0; j < *num_user_fields; j++) {
+            const char *key_0 = tdb_get_field_name(dbs[0], j + 1);
+            const char *key_j = tdb_get_field_name(dbs[i], j + 1);
+
+            if (strcmp(key_0, key_j) != 0) {
+                *equal_fields = 0;
+                break;
             }
         }
 
-        if (i > 0 && n != *num_user_fields)
-            *equal_fields = 0;
+        if (!*equal_fields)
+            break;
+    }
+
+    // if fields are not equal, build a mapping
+    if (!*equal_fields) {
+        *num_user_fields = 0;
+        for (i = 0; i < num_inputs; i++){
+            // skip over timestamp
+            n = tdb_num_fields(dbs[i]) - 1;
+
+            for (j = 0; j < n; j++){
+                // skip over timestamp
+                const char *key = tdb_get_field_name(dbs[i], j + 1);
+                JSLI(ptr, dedup_fields, key);
+                if (!*ptr){
+                    *ptr = (Word_t)key;
+                    ++*num_user_fields;
+                }
+            }
+        }
     }
 
     if (!(fields = malloc(*num_user_fields * sizeof(char*))))
-        DIE("Out of memory");
+            DIE("Out of memory");
 
-    // need to retain order if fields are the same
-    // so we can directly cons the input traildbs
-    if (*equal_fields) {
+    // handle special case of all equal fields
+    if (*equal_fields) { 
         for (i = 0; i < *num_user_fields; i++) {
             // skip over timestamp field
             const char *key = tdb_get_field_name(dbs[0], i + 1);
             fields[i] = key;
         }
-    } else {
+    } else { // otherwise return fields from mapping
         fieldname[0] = i = 0;
         JSLF(ptr, dedup_fields, fieldname);
         while (ptr){
             fields[i++] = (const char*)*ptr;
             JSLN(ptr, dedup_fields, fieldname);
         }
+        JSLFA(tmp, dedup_fields);
     }
 
-    JSLFA(tmp, dedup_fields);
     *out_fields = fields;
     return dbs;
 }

--- a/tests/tdbcli/test_tdbcli.py
+++ b/tests/tdbcli/test_tdbcli.py
@@ -200,6 +200,14 @@ class TestMerge(TdbCliTest):
     def setUp(self):
         self._remove()
 
+    def test_single_traildb(self):
+        tdb_a = self.make_tdb(suffix='_a', index=False)
+        cmd = [TDB, 'merge', '-o', TEST_DB + '_merged', tdb_a]
+        self.tdb_cmd(cmd)
+        stats = Counter(''.join(imap(str, sorted(e.items())))
+                        for e in self.dump(suffix='_merged'))
+        self.assertEquals(stats.values(), [1] * 10)
+
     def test_matching_fields(self):
         tdb_a = self.make_tdb(suffix='_a', index=False)
         tdb_b = self.make_tdb(suffix='_b', index=False)


### PR DESCRIPTION
Issues fixed include:

1. `tdb merge` now works with a single traildb (useful for filtering)
2. Correctly identify when input traildbs have the same fields and use direct cons'ing
3. When merging traildbs with the same fields, return fields in order found in first traildb to avoid failure when cons'ing
4. Check number of user fields against counter after checking for duplicates to avoid edge case where last traildb has a different field name but same number of fields.