### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: c
 matrix:
   include:
     - os: linux
+      arch: amd64
+    - os: linux
+      arch: ppc64le
     - os: osx
 
 before_install:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/traildb/builds/210305950 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!